### PR TITLE
Remove sections from manifest that are actually non-existent.

### DIFF
--- a/src/app.manifest
+++ b/src/app.manifest
@@ -10,36 +10,15 @@
                     "helloWorldRegion"
                 ]
             }
-        },
-        "permissions": {
-            "required": [
-                "shoppingCartContent",
-                "customerData"
-            ],
-            "issued": [
-                "signSellingData"
-            ]
-        },
-        "active": true
+        }
     },
     "api": {
-        "serviceUrls": {
-        },
         "environments": {
             "development": {
                 "serviceUrls": {
                     
                 }
             }
-        },
-        "permissions": {
-            "required": [
-                "shoppingCartContent",
-                "customerData"
-            ],
-            "issued": [
-                "signSellingData"
-            ]
         }
     }
 }


### PR DESCRIPTION
When using `appix init`, the provided manifest contains sections that are actually non-existent features. I've removed them. When we implement these features, we can simply add them back in.